### PR TITLE
Use relative imports to aid using custom versions

### DIFF
--- a/ddbmock/__init__.py
+++ b/ddbmock/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from pyramid.config import Configurator
-from ddbmock.router.pyramid import pyramid_router
+from .router.pyramid import pyramid_router
 
 def noop(*args, **kwargs): pass
 

--- a/ddbmock/router/__init__.py
+++ b/ddbmock/router/__init__.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from importlib import import_module
-from ddbmock.utils import req_logger
-from ddbmock.errors import InternalFailure
-from ddbmock.validators import dynamodb_api_validate
+from ..utils import req_logger
+from ..errors import InternalFailure
+from ..validators import dynamodb_api_validate
 import re, itertools
 
 request_counter = itertools.count()  # atomic counter

--- a/ddbmock/router/pyramid.py
+++ b/ddbmock/router/pyramid.py
@@ -3,8 +3,8 @@
 # pyramid entry point: semantic name
 from __future__ import absolute_import
 
-from ddbmock.router import router
-from ddbmock.errors import DDBError
+from ..router import router
+from ..errors import DDBError
 from pyramid.response import Response
 import json
 

--- a/ddbmock/utils/__init__.py
+++ b/ddbmock/utils/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from .stat import Stat
-from ddbmock import config
+from .. import config
 from threading import Timer
 import logging
 

--- a/ddbmock/validators/__init__.py
+++ b/ddbmock/validators/__init__.py
@@ -2,7 +2,7 @@
 
 from onctuous import Schema, Invalid
 from importlib import import_module
-from ddbmock.errors import ValidationException
+from ..errors import ValidationException
 
 def dynamodb_api_validate(action, post):
     """ Find validator for ``action`` and run it on ``post``. If no validator


### PR DESCRIPTION
I'm using a slightly custom ddbmock in my project (rest of the changes to hopefully eventually get packaged up...) and in order to be able to include it from a subfolder, I had to convert the project to using relative imports internally (as per https://www.python.org/dev/peps/pep-0328/). This makes the import much more portable.
